### PR TITLE
A few cleanups based on Sprocket output

### DIFF
--- a/wdl/deepvariant_retraining.wdl
+++ b/wdl/deepvariant_retraining.wdl
@@ -169,7 +169,7 @@ task training {
     }
 
     output {
-        Array[File] training_dir = glob("~{training_dir}/*")
+        Array[File] training_dir_out = glob("~{training_dir}/*")
     }
 
     runtime {
@@ -282,7 +282,7 @@ workflow DeepVariant_Retraining {
     }
 
     output {
-        Array[File] training_dir=training.training_dir
+        Array[File] training_dir=training.training_dir_out
     }
 
     meta {

--- a/wdl/germline_calling.wdl
+++ b/wdl/germline_calling.wdl
@@ -10,7 +10,7 @@ task haplotypecaller {
         File? intervalFile
         Boolean gvcfMode = false
         Boolean useBestPractices = false
-        String haplotypecallerPassthroughOptions = ""
+        String? haplotypecallerPassthroughOptions = ""
         String annotationArgs = ""
 
         File? pbLicenseBin


### PR DESCRIPTION
This PR adds a few cleanups to the WDL workflows, including:

1. Fixing an issue where an output has the same name as an input in the task scope (the spec says in Appendix B that the task scope, which includes the input block, output block, and private declarations, must have unique names within. I'm not sure how the existing execution engines accept these, but Sprocket won't).
2. Fixes a type mismatch in pre-WDL v1.2. WDL v1.2 introduces the fact that inputs with a default can be provided and optional input and, in the case that optional input is `None`, use the default. However, this was not strictly allowed by the spec until WDL v1.2. Sprocket errors here, and I think rightfully so. Thus, I've backed this out to be an optional task input.